### PR TITLE
Update vanilla-datetimerange-picker.js

### DIFF
--- a/dist/vanilla-datetimerange-picker.js
+++ b/dist/vanilla-datetimerange-picker.js
@@ -1412,14 +1412,14 @@ var DateRangePicker;
                 this.setEndDate(date.clone());
                 if (this.autoApply) {
                   this.calculateChosenLabel();
-                  this.clickApply();
+                  this.clickApply(e);
                 }
             }
 
             if (this.singleDatePicker) {
                 this.setEndDate(this.startDate);
                 if (!this.timePicker && this.autoApply)
-                    this.clickApply();
+                    this.clickApply(e);
             }
 
             this.updateView();


### PR DESCRIPTION
In `use strict` mode, using autoApply generates an error message `Uncaught TypeError: e is undefined vanilla-datetimerange-picker.js:1476:13`.
By changing these two lines the error disappears.