### PR TITLE
fix: event should be fired from the element the date picker is attached to

### DIFF
--- a/dist/vanilla-datetimerange-picker.js
+++ b/dist/vanilla-datetimerange-picker.js
@@ -1473,7 +1473,7 @@ var DateRangePicker;
 
         clickApply: function(e) {
             this.hide();
-            e.target.dispatchEvent(new CustomEvent('apply.daterangepicker', {bubbles: true, detail: this}));
+            this.element.dispatchEvent(new CustomEvent('apply.daterangepicker', {bubbles: true, detail: this}));
         },
 
         clickCancel: function(e) {


### PR DESCRIPTION
Instead of 

```
    window.addEventListener('apply.daterangepicker', function (ev) {
        console.log(ev.detail.startDate.format('YYYY-MM-DD'));
        console.log(ev.detail.endDate.format('YYYY-MM-DD'));
    });
```

We should be able to write:

```
   new DateRangePicker(element...)

   
    element.addEventListener('apply.daterangepicker', function (ev) {
        console.log(ev.detail.startDate.format('YYYY-MM-DD'));
        console.log(ev.detail.endDate.format('YYYY-MM-DD'));
    });
```
