### PR TITLE
rangesLiElList is missing 'var =' which is bad practice (global varia…

### DIFF
--- a/dist/vanilla-datetimerange-picker.js
+++ b/dist/vanilla-datetimerange-picker.js
@@ -655,7 +655,7 @@ var DateRangePicker;
             this.renderCalendar('right');
 
             //highlight any predefined range matching the current start and end dates
-            rangesLiElList = this.container.querySelectorAll('.ranges li');
+            var rangesLiElList = this.container.querySelectorAll('.ranges li');
             for(let i = 0; i < rangesLiElList.length; ++i)
                 rangesLiElList[i].classList.remove('active');
 


### PR DESCRIPTION
changed

rangesLiElList = ...

to

var rangesLiElList = ...

because 

- the missing var is creating a global variable (polluting global namespace)
- not working in strict mode